### PR TITLE
Remove clientTracking from WebSocket.Server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,12 @@ export class WsSocket {
         return enhancedApp.server;
       };
     }
-    this.wss = new WebSocket.Server({ server: enhancedApp.server });
+    this.wss = new WebSocket.Server(
+      { 
+        server: enhancedApp.server,
+        clientTracking: false,
+      }
+    );
 
     enhancedApp.ws = this;
 


### PR DESCRIPTION


<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Previously, the `clientTracking` feature in WebSocket.Server was enabled. Unfortunately, in `socket.ts`, we remove all listeners from the `WebSocket` itself. This causes the `close` behavior removing the Socket from the `clients` list in `WebSocket.Server` not to function. Because the `terminate` functionality provided by `clientTracking` is never used with this project, the easiest solution is to remove it.
<!-- Why are these changes necessary? -->
**Why**:

Prevent leakage of every Socket.

<!-- How were these changes implemented? -->
**How**:

Disabling `clientTracking` functionality of `WebSocket.Server` to eliminate dependency on existing `close` handlers on the `WebSocket` object.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation N/A
- [x] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

